### PR TITLE
Add support for code formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,14 @@
         "@vscode/wasm-wasi": "^1.0.1",
         "os-browserify": "^0.3.0",
         "path-browserify": "^1.0.1",
+        "tmp": "^0.2.3",
         "vscode-languageclient": "^10.0.0-next.3"
       },
       "devDependencies": {
         "@types/glob": "^8.0.0",
         "@types/mocha": "^10.0.1",
         "@types/node": "16.x",
+        "@types/tmp": "^0.2.6",
         "@types/vscode": "1.88.0",
         "@typescript-eslint/eslint-plugin": "^5.45.0",
         "@typescript-eslint/parser": "^5.45.0",
@@ -446,6 +448,13 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
       "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
       "dev": true
+    },
+    "node_modules/@types/tmp": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/vscode": {
       "version": "1.88.0",
@@ -4854,6 +4863,15 @@
       "dependencies": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -421,6 +421,7 @@
     "@types/glob": "^8.0.0",
     "@types/mocha": "^10.0.1",
     "@types/node": "16.x",
+    "@types/tmp": "^0.2.6",
     "@types/vscode": "1.88.0",
     "@typescript-eslint/eslint-plugin": "^5.45.0",
     "@typescript-eslint/parser": "^5.45.0",
@@ -439,6 +440,7 @@
     "@vscode/wasm-wasi": "^1.0.1",
     "os-browserify": "^0.3.0",
     "path-browserify": "^1.0.1",
+    "tmp": "^0.2.3",
     "vscode-languageclient": "^10.0.0-next.3"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode';
 import { createLanguageClient, getServerPlatform, ServerPlatform } from './validator';
 import { dumpAstRequest, dumpDependencyRequest } from './request';
 import { ShaderVariantTreeDataProvider } from './shaderVariant';
+import { HLSLFormattingProvider } from './formatter';
 
 export let sidebar: ShaderVariantTreeDataProvider;
 
@@ -87,6 +88,9 @@ export async function activate(context: vscode.ExtensionContext)
             client.outputChannel.appendLine("No active file for dumping deps tree");
         }
     }));
+    const formattingProvider = new HLSLFormattingProvider();
+    context.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider(HLSLFormattingProvider.selector, formattingProvider));
+    context.subscriptions.push(vscode.languages.registerDocumentRangeFormattingEditProvider(HLSLFormattingProvider.selector, formattingProvider));
 }
 
 

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,0 +1,34 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as tmp from 'tmp';
+import { DocumentSelector } from 'vscode-languageclient';
+
+export class HLSLFormattingProvider implements vscode.DocumentFormattingEditProvider, vscode.DocumentRangeFormattingEditProvider
+{
+    static selector: DocumentSelector = [{ scheme: 'file', language: 'hlsl' }, { language: 'hlsl', scheme: 'untitled' }];
+    async provideDocumentFormattingEdits(document: vscode.TextDocument, options: vscode.FormattingOptions, token: vscode.CancellationToken): Promise<vscode.TextEdit[]>
+    {
+        const tmpFile = tmp.fileSync({ prefix: 'hlsl-', postfix: '.cpp' });
+        try {
+            fs.writeFileSync(tmpFile.name, document.getText());
+            const doc = await vscode.workspace.openTextDocument(tmpFile.name);
+            const edits = await vscode.commands.executeCommand<vscode.TextEdit[]>('vscode.executeFormatDocumentProvider', doc.uri, options);
+            return edits || [];
+        } finally {
+            tmpFile.removeCallback();
+        }
+    }
+
+    async provideDocumentRangeFormattingEdits(document: vscode.TextDocument, range: vscode.Range, options: vscode.FormattingOptions, token: vscode.CancellationToken): Promise<vscode.TextEdit[]>
+    {
+        const tmpFile = tmp.fileSync({ prefix: 'hlsl-', postfix: '.cpp' });
+        try {
+            fs.writeFileSync(tmpFile.name, document.getText());
+            const doc = await vscode.workspace.openTextDocument(tmpFile.name);
+            const edits = await vscode.commands.executeCommand<vscode.TextEdit[]>('vscode.executeFormatRangeProvider', doc.uri, range, options);
+            return edits || [];
+        } finally {
+            tmpFile.removeCallback();
+        }
+    }
+}


### PR DESCRIPTION
Same implementation as [Shader languages support for VS Code](https://github.com/stef-levesque/vscode-shader)